### PR TITLE
[Galaxy A5 (2015)] Add TouchWiz kernel

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -311,5 +311,13 @@ devicenames = cancro
 # Galaxy A5 for Cyanogenmod
 [a5ulte]
 author = "DeadSquirrel01"
+kernelstring = "NetHunter Kernel CM"
 version = "1.3"
+devicenames = a5ulte a5ultexx SM-A500FU
+
+# Galaxy A5 for TouchWiz (Europe)
+[a5ulte-touchwiz]
+author = "DeadSquirrel01"
+kernelstring = "NetHunter Kernel TW"
+version = "1.0"
 devicenames = a5ulte a5ultexx SM-A500FU

--- a/kernels.txt
+++ b/kernels.txt
@@ -92,6 +92,8 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # git clone https://github.com/jcadduono/nethunter_kernel_klte.git -b cm-13.0
 
 # - Samsung Galaxy A5
+# TouchWiz
+# git clone https://github.com/DeadSquirrel01/nethunter-kernel-a5ulte.git -b touchwiz-6.0
 # AOSP/CM
 # git clone https://github.com/DeadSquirrel01/nethunter-kernel-a5ulte.git -b cm-13.0
 


### PR DESCRIPTION
Well, In this pull request I added support for touchwiz kernel, because after added cm kernel support, I thinked: why don't I port it on tw kernel, too? Here's the result :)