### PR TITLE
[shamucm]:v1.3: 3.10.102-nethunter-g79824c9-03314-g0757761

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -56,7 +56,7 @@ block = /dev/block/platform/msm_sdcc.1/by-name/boot
 # Nexus 6 for CyanogenMod
 [shamucm]
 author = "discipuloosho"
-version = "1.1"
+version = "1.3"
 devicenames = shamu
 block = /dev/block/platform/msm_sdcc.1/by-name/boot
 


### PR DESCRIPTION
BCL not interfere in APQ8084 chipset
KGSL tunned up
READAHEAD optimized
