### PR TITLE
[dogo] Add kernel

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -328,3 +328,9 @@ author = "DeadSquirrel01"
 kernelstring = "NetHunter Kernel TW"
 version = "1.0"
 devicenames = a5ulte a5ultexx SM-A500FU
+
+# Sony Xperia ZR for Cyanogenmod
+[dogo]
+author = "Daedroza"
+version = "1.0"
+devicenames = dogo

--- a/kernels.txt
+++ b/kernels.txt
@@ -100,6 +100,10 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # AOSP/CM
 # git clone https://github.com/DeadSquirrel01/nethunter-kernel-a5ulte.git -b cm-13.0
 
+# - Sony Xperia ZR
+# CM 13.0/CM-14.0
+# git clone https://github.com/daedroza/nethunter_kernel_apq8064.git -b master
+
 # - Xiaomi Mi3/4
 # CM 13.0
 # git clone https://github.com/binkybear/android_kernel_xiaomi_cancro.git -b cm-13.0


### PR DESCRIPTION
*HCI USB is disabled at the moment.

*Wireless adapater might not start up, here is a solution to put it
 into monitor mode on directly :
 iwlist wlan1 scan
 ifconfig wlan1 down
 iwconfig wlan1 mode monitor
 ifconfig wlan1 up

*ZD1201 wireless usb adapters are also not supported at the moment.

*Atheroes, RALINK, Atmel supported.

*Tested on ath9k_htc.