### PR TITLE
[Huawei Honor 5x] Add NetHunter Kernel Support

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -400,3 +400,9 @@ devicenames = nobleltechn nobleltezt SM-N9200 SM-N9208
 author = "jcadduono"
 version = "1.4"
 devicenames = nobleltespr noblelteusc SM-N920P SM-N920R4
+
+# Huawei Honor 5x
+[kiwi]
+author = "DeadSquirrel01"
+version = "1.0"
+devicenames = kiwi

--- a/kernels.txt
+++ b/kernels.txt
@@ -124,6 +124,10 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # CM 13.0
 # git clone https://github.com/binkybear/android_kernel_xiaomi_cancro.git -b cm-13.0
 
+# - Huawei Honor 5x
+# CM 13.0
+# git clone https://github.com/DeadSquirrel01/android_kernel_huawei_kiwi.git -b cm-13.0
+
 # - Toolchain
 # Google reference
 # git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.7


### PR DESCRIPTION
Hi, today i've ported NetHunter for Huawei Honor 5x
Kernel's patch commits:
Packet injection patch:  https://github.com/DeadSquirrel01/android_kernel_huawei_kiwi/commit/7264c8c6fef052a77947f939e6e2629a6d967eb8
HID Gadget keyboard/mouse patch:  https://github.com/DeadSquirrel01/android_kernel_huawei_kiwi/commit/c22e82d87ece37957412aa0cc537ea04996828e1
CD-ROM Patch for DriveDroid:  https://github.com/DeadSquirrel01/android_kernel_huawei_kiwi/commit/4960945660ad59fb5603d43d05b8815fc532c02d

This kernel is not tested, but at least it has compiled :D
Hope you appreciate :)
Regards