### PR TITLE
[NOT READY] Updated devices for "gtaxlwifi" Support

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -380,6 +380,13 @@ kernelstring = "NetHunter Kernel TW"
 version = "1.0"
 devicenames = a5ulte a5ultexx SM-A500FU
 
+# Galaxy Tab A6 for TouchWiz (Europe)
+[gtaxlwifi]
+author = "kimocoder"
+version = "1.0"
+devicenames = "gtaxlwifi"
+arch = "armhf"
+
 # Sony Xperia ZR for Cyanogenmod
 [dogo]
 author = "Daedroza"


### PR DESCRIPTION
Samsung Galaxy Tab A6 (SM-T580) with codename "gtaxlwifi" added. Tested and working directly from the NetHunter.apk installation, which my other phones (eg. the Xperia Z5 E6653) struggles with java error, md5 mismatch and some of the tools needs to be placed manually. The Samsung still needs a kernel with mac80211 network stack and the monitor patch and drivers/firmware in general.. This will be added alongside the E6653 kernel and support I made when I arrive back home in a week. Best regards!