### PR TITLE
Update Nexus 5 Nougat caf kernel and change directory name from 'hammerheadcaf' to 'hammerheadcafcm'

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -96,7 +96,7 @@ block = /dev/block/platform/msm_sdcc.1/by-name/boot
 # Nexus 5 - CyanogenMod 14.1 CAF - Kexec hardboot patch - DirtyCOW patched
 [hammerheadcafcm]
 author = "chrisk44"
-version = "1.0"
+version = "1.1"
 devicenames = hammerheadcaf
 block = /dev/block/platform/msm_sdcc.1/by-name/boot
 


### PR DESCRIPTION
The kernel is updated with the latest commits from CyanogenMod. The directory should be hammerheadcafcm, not hammerheadcaf, or it doesn't build.