### PR TITLE
Add hammerheadmon-nougat

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -73,8 +73,8 @@ block = /dev/block/platform/soc.0/f9824900.sdhci/by-name/boot
 
 # Nexus 5 with Nexmon Wireless Monitoring
 [hammerheadmon]
-author = "Binkybear"
-version = "1.0"
+author = "Binkybear (6.0) & AutinDroid (7.0+)"
+version = "1.0" 
 kernelstring = "NetHunter Nexmon kernel"
 devicenames = hammerhead
 block = /dev/block/platform/msm_sdcc.1/by-name/boot

--- a/devices.cfg
+++ b/devices.cfg
@@ -74,7 +74,7 @@ block = /dev/block/platform/soc.0/f9824900.sdhci/by-name/boot
 # Nexus 5 with Nexmon Wireless Monitoring
 [hammerheadmon]
 author = "Binkybear (6.0) & AutinDroid (7.0+)"
-version = "1.0" 
+version = "1.0"
 kernelstring = "NetHunter Nexmon kernel"
 devicenames = hammerhead
 block = /dev/block/platform/msm_sdcc.1/by-name/boot

--- a/kernels.txt
+++ b/kernels.txt
@@ -45,6 +45,7 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # CM
 # git clone https://github.com/jcadduono/nethunter_kernel_hammerhead.git nexus5-cm
 # git clone https://github.com/chrisk44/android_kernel_lge_hammerhead.git -b cm-14.1-caf
+# git clone https://github.com/AutinDroid/HammerheadMon-Kernel.git -b Nexmon-Patches
 
 # - Nexus 4
 # git clone https://github.com/binkybear/kernel_msm.git -b android-msm-mako-3.4-kitkat-mr2 mako


### PR DESCRIPTION
This is Chrisk44's kernel patched for Nexmon in chroot. Source can be found here: https://github.com/AutinDroid/HammerheadMon-Kernel/tree/Nexmon-Patches
This kernel is for AOSP based nougat ROMs on the Nexus 5.
