### PR TITLE
Nexus 9 kernel updated

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -21,8 +21,8 @@ block = /dev/block/platform/dw_mmc.0/by-name/boot
 
 # Nexus 9
 [flounder]
-author = "Binkybear"
-version = "2.1"
+author = "Binkybear (5.1-6.0) & SecurityAddicted (7.0+)"
+version = "2.1 (5.1-6.0) & 1.0 (7.0+)"
 arch = arm64
 devicenames = flounder
 block = /dev/block/platform/sdhci-tegra.3/by-name/LNX

--- a/kernels.txt
+++ b/kernels.txt
@@ -14,6 +14,7 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # git clone https://github.com/binkybear/nexus10-5.git -b android-exynos-manta-3.4-lollipop-release
 
 # - Nexus 9
+# git clone https://github.com/SecurityAddicted/ElementalX-N9-Nethunter.git nexus9-7
 # git clone https://github.com/binkybear/flounder.git -b android-tegra-flounder-3.10-marshmallow-release nexus 9-6
 # git clone https://github.com/binkybear/flounder.git -b android-tegra-flounder-3.10-lollipop-release  nexus9-5
 


### PR DESCRIPTION
This is an updated kernel for the Nexus 9.
It uses the ElementalX 5.07 kernel (up to Nougat 7.1.1) as base with the Nethunter patches (Injection - CDROM - HID keyboard)  applied.
Hope it will help.
Sources: https://github.com/SecurityAddicted/ElementalX-N9-Nethunter