### PR TITLE
add lg g2's kernel

### DIFF
--- a/kernels.txt
+++ b/kernels.txt
@@ -2,6 +2,11 @@ Locations of all kernels used in Kali NetHunter.
 
 If you wish to add a kernel/new device, leave a link to source here and feel free to add your name if you wish:
 
+# - LG G2 
+# vs980
+# git clone https://github.com/huzaifa-007/lg-g2-nethunter.git -b master
+# CM14
+
 # - ZTE Axon 7
 # MiFavor
 # git clone https://github.com/jcadduono/android_kernel_zte_msm8996.git -B nethunter-6.0


### PR DESCRIPTION
Compiled the nethunter kernel for lg g2 vs980 "for now" according to the guide at nethunter's page 
kernel is tested and working properly