### PR TITLE
Update devices.cfg

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -138,7 +138,7 @@ devicenames = shieldtablet tn8
 [oneplusxcm]
 author = "jcadduono"
 version = "1.1"
-devicenames = ONE onyx OnePlusX oneplusx
+devicenames = OnePlus onyx OnePlusX oneplusx
 
 # OnePlusTwo for Cyanogenmod
 [oneplus2cm]


### PR DESCRIPTION
OnePlusX with latest TWRP Recovery has ro_product_device property equal to the following string "OnePlus", but in the previous config file it does not exist, line 141.
Adding it fixes the "Unsupported device" false positive error. Tested on my own OPX.
However I noticed compatibility issues of nethunter kernel with new OPX bootloader causing system not to boot at all after nh kernel flash. (Phone boots to bootloader instead). I will try to contribute in fixing the compatibility issue later.