### PR TITLE
Added Support For Moto G5 Plus (potter)

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -604,3 +604,13 @@ kernelstring = "NetHunter Kernel For Yu Yunique"
 arch = armhf
 block = /dev/block/bootdevice/by-name/boot
 devicenames = jalebi YUNIQUE YU4711
+
+# Motorola Moto G5 Plus
+[potter]
+author = "chankruze"
+version = "1.0"
+kernelstring = "NetHunter kernel for Motorola 
+Moto G5 Plus"
+arch = arm
+devicenames = potter
+block = /dev/bloc/bootdevice/by-name/boot

--- a/devices.cfg
+++ b/devices.cfg
@@ -609,8 +609,7 @@ devicenames = jalebi YUNIQUE YU4711
 [potter]
 author = "chankruze"
 version = "1.0"
-kernelstring = "NetHunter kernel for Motorola 
-Moto G5 Plus"
+kernelstring = "NetHunter kernel for Motorola Moto G5 Plus"
 arch = arm
-devicenames = potter
+devicenames = potter potter_retail
 block = /dev/bloc/bootdevice/by-name/boot

--- a/kernels.txt
+++ b/kernels.txt
@@ -197,6 +197,10 @@ git clone https://github.com/zanezam/boeffla-kernel-cm-oneplus3.git -b t_boeffla
 # - Yu Yunique
 # git clone https://github.com/thelazyindian/kernel_8916.git -b cm-14.1-nethunter
  
+# Motorola Moto G5 Plus
+# Lineage OS 14.1 Based ROM's
+# git clone https://github.com/chankruze/potter_kali_kernel -b cm-14.1
+
 # - Toolchain
 # Google reference
 # git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.7


### PR DESCRIPTION
The compiled update package is posted [here](https://geekofia.wordpress.com/2019/01/22/kali-nethunter-overlay-potter/).
- based on lineage os 14.1 kernel