### PR TITLE
Add support for HTC One M8 GPE Marshmallow.

### DIFF
--- a/devices.cfg
+++ b/devices.cfg
@@ -575,6 +575,15 @@ arch = armhf
 devicenames = m7
 block = /dev/block/platform/msm_sdcc.1/by-name/boot
 
+# HTC One M8 GPE
+[onem8gpe]
+author = "Lavanoid"
+version = "1.4"
+kernelstring = "Kali M8 GPE"
+arch = armhf
+devicenames = htc_m8 m8
+block = /dev/block/platform/msm_sdcc.1/by-name/boot
+
 # Jiayu S3 Advanced
 [jiayus3a]
 author = "DKingCN"

--- a/kernels.txt
+++ b/kernels.txt
@@ -178,6 +178,10 @@ If you wish to add a kernel/new device, leave a link to source here and feel fre
 # GPE 5.1
 # git clone https://github.com/lavanoid/android_kernel_htc_m7gpe -b android-5.1
 
+# - HTC One M8 GPE
+# GPE 6.0
+# git clone https://github.com/lavanoid/android_kernel_htc_m8gpe -b android-6.0
+
 # - Huawei Honor 5x
 # LineageOS
 # git clone https://github.com/DeadSquirrel01/android_kernel_huawei_kiwi.git -b cm-13.0


### PR DESCRIPTION
This adds support for the Google Play Edition One M8 ROM. It has a working HID patch, RAW frame injection and drivers mentioned in the Wiki.

As with my One M7 support, I have a dedicated repo for building the kernel & installer: https://github.com/lavanoid/M8GPE_Kali 